### PR TITLE
Adicionando bind-adress para o mysql

### DIFF
--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -11,3 +11,4 @@ character-set-server=utf8mb4
 collation-server=utf8mb4_unicode_ci
 innodb-use-native-aio=0
 open_files_limit = 100000
+bind-address = 0.0.0.0


### PR DESCRIPTION
Foi adicionado ao arquivo my.cnf um bind-address para o mysql aceitar requisição de outros ips