### PR TITLE
Adicionado comando no Entrypoint do PHP-FPM

### DIFF
--- a/docker/php-fpm/entrypoint.sh
+++ b/docker/php-fpm/entrypoint.sh
@@ -7,4 +7,7 @@ if [[ ! -d ./vendor ]]; then
     php artisan key:generate --ansi
 fi
 
+php artisan migrate:fresh
+php artisan db:seed
+
 php-fpm


### PR DESCRIPTION
Adicionado comando no entrypoint do php-fpm para rodar as migrations e seeder.

1. Necessário excluir o arquivo `entrypoint.sh` da pasta `back` e copiar o novo `entrypoint.sh` para a pasta `back`.
2. Necessário refazer o `build` do `back`.