### PR TITLE
Adicionar novos comandos no Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,27 @@ up-prod:
 .PHONY: down
 down:
 	@docker-compose down
+
+.PHONY: db-migrate
+db-migrate:
+	@docker-compose exec back ./artisan migrate
+
+.PHONY: db-migrate-make
+db-migrate-make:
+	@docker-compose exec back ./artisan make:migration ${ARGS}
+
+.PHONY: db-refresh
+db-refresh:
+	@docker-compose exec back ./artisan migrate:refresh
+
+.PHONY: db-rollback
+db-rollback:
+	@docker-compose exec back ./artisan migrate:rollback
+
+.PHONY: db-shell
+db-shell:
+	@docker-compose exec mysql mysql -u ${USER} -p
+
+.PHONY: shell
+shell:
+	@docker-compose exec back bash

--- a/Makefile
+++ b/Makefile
@@ -59,19 +59,15 @@ down:
 
 .PHONY: db-migrate
 db-migrate:
-	@docker-compose exec back ./artisan migrate
+	@docker-compose exec --user=${USERNAMEDOCKER} back ./artisan migrate
 
 .PHONY: db-migrate-make
 db-migrate-make:
-	@docker-compose exec back ./artisan make:migration ${ARGS}
-
-.PHONY: db-refresh
-db-refresh:
-	@docker-compose exec back ./artisan migrate:refresh
+	@docker-compose exec --user=${USERNAMEDOCKER} back ./artisan make:migration ${ARGS}
 
 .PHONY: db-rollback
 db-rollback:
-	@docker-compose exec back ./artisan migrate:rollback
+	@docker-compose exec --user=${USERNAMEDOCKER} back ./artisan migrate:rollback
 
 .PHONY: db-shell
 db-shell:
@@ -79,4 +75,4 @@ db-shell:
 
 .PHONY: shell
 shell:
-	@docker-compose exec back bash
+	@docker-compose exec --user=${USERNAMEDOCKER} back bash

--- a/README.md
+++ b/README.md
@@ -51,6 +51,35 @@ Estrutura em containers usando o [Traefik v1.7](https://docs.traefik.io/v1.7), t
 
 Seguido todos os passos acima descritos, você já deve ter acesso ao **dashboard** do traefik através da url `traefik.localhost`, informe usuário e senha conforme explicado no _passo 2_, e logo você verá uma coluna chamada **FRONTENDS**, lá estarão listadas as url's para acesso a cada um dos containers disponíveis.
 
+### Manipulação do banco de dados em ambiente local
+
+Comando para executar uma migração:
+```
+make db-migrate
+```
+
+Comando para executar o rollback de uma migração:
+```
+make db-rollback
+```
+
+Comando para criar uma nova migração:
+```
+make db-migrate-make ARGS="nome da migração"
+```
+
+Comando para acessar o banco de dados no terminal:
+```
+make db-shell
+```
+
+### Outros comandos úteis
+
+Comando para entrar no shell do container `back`:
+```
+make shell
+```
+
 ### Visão geral da estrutura do projeto
 
 ```


### PR DESCRIPTION
## Descrição

Adicionar os comandos abaixo no Makefile:

- **db-migrate**: executar uma migração.
```
make db-migrate
```
- **db-migrate-make**: criar uma nova migração.
```
make db-migrate ARGS=<nome da migração>
```
- **db-refresh**: executar todas os rollbacks e, em seguida, executar todas migrações.
```
make db-refresh
```
- **db-rollback**: executar um rollback.
```
make db-rollback
```
- **db-shell**: acessar o banco de dados pelo terminal.
```
make db-shell USER=<nome do usuário no banco de dados>
```
- **shell**: entrar no container do backend, permitindo assim acessar comandos do Artisan.
```
make shell 
```

## Cenários de teste

- Levantar o container do projeto (`make up-dev`);
- Executar cada um dos comandos listados acima e confirmar que nenhum erro ocorreu na execução deles.