### PR TITLE
Mudar o comando de clones dos repositórios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ start-prod: front back prod network-external build-no-cache up-prod
 .PHONY: front
 front:
 	if [ ! -d "./front" ]; then \
-		git clone https://github.com/MANAUS-MAIS-HUMANA/mmh-web.git front; \
+		git clone git@github.com:MANAUS-MAIS-HUMANA/mmh-web.git front; \
 		cp ./docker/node/Dockerfile ./front/; \
 	fi
 
 .PHONY: back
 back:
 	if [ ! -d "./back" ]; then \
-		git clone https://github.com/MANAUS-MAIS-HUMANA/mmh-service.git back; \
+		git clone git@github.com:MANAUS-MAIS-HUMANA/mmh-service.git back; \
 		chmod -R 755 ./back/storage ./back/bootstrap/cache/; \
 	fi
 


### PR DESCRIPTION
## Mudança

Mudar o Makefile para fazer o git clone usando uma URL SSH, em vez de usar a URL HTTPS. Isso evita que o usuário precise inserir username e password toda vez que ele precisar fazer um git push aos repositórios do front e back.

## Como testar

- Faça um clone deste repositório em um outro diretório do seu sistema;
- Execute o comando `make back front`.

Resultado esperado: os diretórios `back` e `front` serem clonados com sucesso no novo repositório.