### PR TITLE
Alteração no entrypoint.sh do PHP-FPM

### DIFF
--- a/docker/php-fpm/entrypoint.sh
+++ b/docker/php-fpm/entrypoint.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+composer install
+php artisan package:discover --ansi
+
 if [[ ! -d ./vendor ]]; then
-    composer install
-    php artisan package:discover --ansi
     php -r "file_exists('.env') || copy('.env.example', '.env');"
     php artisan key:generate --ansi
 fi
+
+php artisan config:clear
 
 php-fpm


### PR DESCRIPTION
Os comandos `composer install` e `php artisan package:discover --ansi` foram postos fora da verificação da pasta `vendor`, evitando assim, que sempre que haja um pacote novo, seja necessário instalá-lo manualmente.

Incluído também o comando `php artisan config:clear` para limpar configurações em cache.