### PR TITLE
Adicionar variáveis de ambiente para o front

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,7 @@
 COMPOSE_PROJECT_NAME=mmh
 
 APP_NAME=mmh
+APP_PORT=80
 DOMAIN=localhost
 # requirido em desenvolvimento
 USERNAMEDOCKER=mmh

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ back:
 .PHONY: dev
 dev:
 	cp .env-dev .env;
+	cp ./front/.env.local ./front/.env;
 	cp ./docker/nginx/back/default-dev.conf ./docker/nginx/back/default.conf;
 	rm -f acme.json;
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,7 +24,7 @@ services:
       args:
         - USERNAME=${USERNAMEDOCKER}
     environment:
-      - FRONT_URL=http://front.${DOMAIN}
+      - FRONT_URL=http://front.${DOMAIN}:${APP_PORT}
 
   # frontend
   front:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: ${APP_NAME}_traefik
     image: traefik:${TRAEFIK_VERSION}
     ports:
-      - 80:80
+      - ${APP_PORT}:80
     labels:
       - traefik.enable=true
       - traefik.port=8080
@@ -89,6 +89,8 @@ services:
       - internal
     environment:
       - JWT_SECRET=${JWT_SECRET}
+      - APP_PORT=${APP_PORT}
+      - DOMAIN=${DOMAIN}
     tty: true
 
   # banco de dados


### PR DESCRIPTION
## Descrição

Adicionar a variável de ambiente "APP_PORT". Ela vai permitir ao dev selecionar uma porta diferente da 80 para levantar a aplicação.

Além disso, vamos exportar o valor da variável "DOMAIN" para o front. Com isso, será possível montar a URL para enviar requisições ao backend.

## Setup

- Este PR precisa ser testado em conjunto com [esta PR do front](https://github.com/MANAUS-MAIS-HUMANA/mmh-web/pull/14). 
- Para mudar o valor da porta para uma outra diferente da padrão (80), atualize o arquivo `.env-dev` com o novo valor da porta na variável `APP_PORT`.
- Execute o comando `make dev` para adicionar as novas variáveis de ambiente no arquivo .env (nesse procedimento, ele vai apagar qualquer outra alteração feita no ".env". Portanto, lembre-se de guardar algo que queira antes de executar o comando).

## Cenários de teste

- Ver os testes na [PR 14](https://github.com/MANAUS-MAIS-HUMANA/mmh-web/pull/14). 