### PR TITLE
Adicionar a variável BACKEND_URL

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -2,6 +2,7 @@ COMPOSE_PROJECT_NAME=mmh
 
 APP_NAME=mmh
 APP_PORT=80
+BACKEND_URL=http://back.localhost
 DOMAIN=localhost
 # requirido em desenvolvimento
 USERNAMEDOCKER=mmh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - APP_PORT=${APP_PORT}
       - DOMAIN=${DOMAIN}
+      - BACKEND_URL=${BACKEND_URL}
     tty: true
 
   # banco de dados


### PR DESCRIPTION
## Descrição

Em vez de passar apenas o domínio para o container do front-end, vamos passar toda a URL do backend.

Passar apenas o domínio não é o suficiente, pois em produção é preciso mudar também o protocolo (usar https em vez de http) e o subdomínio. Portanto, vamos encapsular toda essa informação em uma única variável.

## Como testar

- Inserir a variável de ambiente `BACKEND_URL=http://back.localhost` no arquivo `.env-dev`, caso não tenha.
- Seguir os passos descritos na [PR](https://github.com/MANAUS-MAIS-HUMANA/mmh-web/pull/14) para fazer as demais configurações.