### PR TITLE
Atualiza o arquivo docker-compose para o ambiente de produção

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,48 +1,196 @@
 version: "3.4"
 
 services:
-  # proxy reverso
   traefik:
+    image: traefik:v1.7.24-alpine
     command:
       - --api
       - --debug=false
       - --logLevel=ERROR
       - --entrypoints=Name:http Address::80 Redirect.EntryPoint:https
       - --entrypoints=Name:https Address::443 TLS
-      - --defaultentrypoints=http,https
+      - --defaultentrypoints=https,http
+      - --ping.entrypoint=http
+      - --retry
       - --acme
-      - --acme.storage=acme.json
+      - --acme.acmeLogging=true
+      - --acme.storage=/certificates/acme.json
+      - --acme.caServer=https://acme-v02.api.letsencrypt.org/directory
       - --acme.entryPoint=https
       - --acme.onHostRule=true
       - --acme.httpChallenge.entryPoint=http
       - --acme.email=${TRAEFIK_ACME_EMAIL}
       - --docker
+      - --docker.swarmMode
       - --docker.exposedbydefault=false
       - --docker.domain=${DOMAIN}
-      - --docker.watch=true
+      - --docker.watch
       - --docker.endpoint=unix:///var/run/docker.sock
+      - --constraints=tag==mmh_external
     ports:
+      - "80:80"
       - "443:443"
     volumes:
-      - ./acme.json:/acme.json
-
-  # servidor web para o back
-  nginx:
-    build:
-      target: production
+      - traefik-data:/certificates
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+    networks:
+      - mmh_external
+      - internal
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.service-type != db
+        preferences:
+          - spread: node.hostname
+      update_config:
+        delay: 5s
+        order: start-first
+        parallelism: 1
+      restart_policy:
+        condition: any
+        delay: 0s
+        max_attempts: 10
+        window: 30s
+      labels:
+        - traefik.enable=true
+        - traefik.port=8080
+        - traefik.frontend.rule=Host:proxy.${DOMAIN}
+        - traefik.docker.network=mmh_external
+        - traefik.tags=mmh_external
+        - traefik.frontend.auth.basic.users=${TRAEFIK_AUTH}
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost/ping || exit 1"]
+      interval: 10s
+      retries: 3
+      start_period: 30s
+      timeout: 5s
 
   # backend
   back:
-    build:
-      target: production
+    image: manausmaishumana/back:latest
     environment:
-      - FRONT_URL=${DOMAIN}
+      - FRONT_URL=https://app.${DOMAIN}
+    networks:
+      - mmh_external
+      - internal
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.service-type != db
+        preferences:
+          - spread: node.hostname
+      update_config:
+        delay: 5s
+        order: start-first
+        parallelism: 1
+      restart_policy:
+        condition: any
+        delay: 0s
+        max_attempts: 10
+        window: 30s
+      labels:
+        - traefik.enable=true
+        - traefik.backend=back
+        - traefik.port=80
+        - traefik.frontend.rule=Host:cluster1.${DOMAIN}
+        - traefik.tags=mmh_external
+        - traefik.docker.network=mmh_external
+    secrets:
+      - source: mmh-back-app_v1
+        target: /var/www/.env
+        mode: 0644
+    # healthcheck:
+    #   test: ["CMD-SHELL", "nc -z 127.0.0.1 80 || exit 1"]
+    #   interval: 10s
+    #   retries: 3
+    #   start_period: 30s
+    #   timeout: 5s
 
   # frontend
   front:
-    build:
-      target: production
-    command: npm run serve -- --port 8000
-    labels:
-      - traefik.port=443
-      - traefik.frontend.rule=Host:${DOMAIN}
+    image: manausmaishumana/front:latest
+    environment:
+      - NODE_ENV=production
+    networks:
+      - mmh_external
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.service-type != db
+        preferences:
+          - spread: node.hostname
+      update_config:
+        delay: 5s
+        order: start-first
+        parallelism: 1
+      restart_policy:
+        condition: any
+        delay: 0s
+        max_attempts: 10
+        window: 30s
+      labels:
+        - traefik.enable=true
+        - traefik.backend=front
+        - traefik.port=80
+        - traefik.frontend.rule=Host:app.${DOMAIN}
+        - traefik.tags=mmh_external
+        - traefik.docker.network=mmh_external
+    # healthcheck:
+    #   test: ["CMD-SHELL", "nc -z 127.0.0.1 80 || exit 1"]
+    #   interval: 10s
+    #   retries: 3
+    #   start_period: 30s
+    #   timeout: 5s
+
+  mysql:
+    image: manausmaishumana/mysql:latest
+    networks:
+      - internal
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.service-type == db
+        preferences:
+          - spread: node.hostname
+      update_config:
+        delay: 5s
+        order: start-first
+        parallelism: 1
+      restart_policy:
+        condition: any
+        delay: 0s
+        max_attempts: 10
+        window: 30s
+      labels:
+        - traefik.enable=false
+    environment:
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_ROOT_PASSWORD_FILE=/.env
+    secrets:
+      - source: mmh-database-mysql_v2
+        target: /.env
+
+secrets:
+  mmh-back-app_v1:
+    external: true
+  mmh-database-mysql_v2:
+    external: true
+
+networks:
+  mmh_external:
+    driver: overlay
+    external: true
+  internal:
+    driver: overlay
+    external: false
+
+volumes:
+  traefik-data:


### PR DESCRIPTION
## Descrição

Atualiza o arquivo do docker-compose de produção com base no ambiente Docker Swarm que foi configurado, lista de mudanças:

- Adiciona o Travis C! para fazer o _build_ e _push_ da imagem `manausmaishumana/mysql`, para o branch `master`
- Fixa a versão do traefik para `traefik:v1.7.24-alpine`
- Configura o modo Swarm para o traefik
- Configura o DNS para as aplicações (proxy, front e back)
- Configura parâmetros de deploy do Swarm para as aplicações 
- Configura dados sensíveis em secrets do Docker Swarm