### PR TITLE
Alterar configurações de localidade no MySQL

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -7,6 +7,15 @@ FROM mysql:${MYSQL_VERSION}
 
 ARG TZ=UTC
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
   && echo $TZ > /etc/timezone \
   && chown -R mysql:root /var/lib/mysql/


### PR DESCRIPTION
## Descrição

Alterar as configurações de localidade no container do MySQL. Com isso, vamos poder executar inserções de strings aceituadas, o que não é possível de fazer hoje (antes, qualquer caractere acentuado era ignorado).

## Como testar

- Levantar todos os containers: `make up-dev`;
- Abrir o container do MySQL: `docker exec -it <container ID> bash`;
- Escrever uma palavra acentuada no terminal.

Resultado esperado: o terminal tem que aceitar qualquer acento ou caractere especial.